### PR TITLE
Update wildlfy-cli to newer version #12

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ pluginBundle {
 dependencies {
     compile(kotlin("stdlib-jdk8", kotlinVersion))
     runtime(kotlin("reflect", kotlinVersion))
-    compile("org.wildfly", "wildfly-cli", "8.2.1.Final")
+    compile("org.wildfly.core", "wildfly-cli", "7.0.0.Final")
 
     compileOnly(gradleApi())
 


### PR DESCRIPTION
This newer wildfly-cli supports batch commands. Note the group name is org.wildfly.core instead of org.wildfly

Tested with the steps described on the README as well