### PR TITLE
Do not depend on build task, lazily resolve file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can also restart the wildfly after the deployment (and await it), analogous 
 ```kotlin
     reload = false // default for reload is true, so deactivate it first
     restart = true
-    awaitRestart = true 
+    awaitRestart = true
 ```
 
 You can also deploy to WildFly in domain mode, but only one server group per task
@@ -108,14 +108,14 @@ task deployDomain(type: DeployWildflyTask) {
     user = deploy.user
     password = deploy.password
     deploymentName = project.name
-    runtimeName = "${project.name}-${project.version}.war"
-    file = "$buildDir/libs/${project.name}-${project.version}.war"
+    runtimeName = tasks.war.archiveFileName
+    file = tasks.war.archiveFile
     // redeploy if artifact with same name already deployed
     undeployBeforehand = true
     // server group of domain mode
     domainServerGroup = "main-server-group"
     // ask to restart servers after deploy instead of only reload them
-    restart = true 
+    restart = true
     reload = false
 }
 ```
@@ -148,10 +148,10 @@ task("deploy", DeployWildflyTask::class) {
     port = 9090
     user = "mgmt_user"
     password = "mgmt_password"
-    deploymentName = project.name                //cli: --name=$runtimeName
-    runtimeName = "${project.name}-$version.war" //cli: --runtime-name=$runtimeName
-    // filepath, here a war example
-    file = "$buildDir/libs/${project.name}-$version.war".apply { println("file=$this") }
+    deploymentName.set(project.name)                 //cli: --name=$runtimeName
+    runtimeName.set(tasks.war.get().archiveFileName) //cli: --runtime-name=$runtimeName
+    // Using war.archiveFile will make the deploy task depend on the war task implicitly, no need for dependsOn("war")
+    file.set(tasks.war.get().archiveFile)
 }
 ```
 
@@ -195,7 +195,7 @@ $ ./gradlew clean build publish
 
 This will deploy the locally build plugin jar into your local maven repo and also into `build/lib`.
 
-To use your locally build plugin you can just 
+To use your locally build plugin you can just
 [override the plugin resolutionStrategy](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_resolution_rules)
 inside your settings.gradle(.kts) file.
 
@@ -229,7 +229,7 @@ pluginManagement {
     repositories {
         maven {
             // this is the build folder of your local wildfly-deploy-gradle-plugin repository, you might need to adapt this
-            url = uri("build/lib") 
+            url = uri("build/lib")
         }
         // or
         mavenLocal()
@@ -239,4 +239,3 @@ pluginManagement {
     }
 }
 ```
-

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     kotlin("jvm") version "1.3.21"
-    id("com.mkring.wildlydeplyplugin.deploy-wildfly-plugin") version "0.2.10"
+    id("com.mkring.wildlydeplyplugin.deploy-wildfly-plugin") version "0.2.12"
     war
 }
 buildscript {

--- a/integration/build.gradle.kts
+++ b/integration/build.gradle.kts
@@ -64,13 +64,14 @@ task("deploy", DeployWildflyTask::class) {
     port = 9990
     user = "mgmt"
     password = "1234"
-    deploymentName = project.name
-    runtimeName = "${project.name}-$version.war"
-    file = "$buildDir/libs/${project.name}-$version.war".apply { println("file=$this") }
+    deploymentName.set(project.name)
+    runtimeName.set(tasks.war.get().archiveFileName)
+    // Using war.archiveFile will make the deploy task depend on the war task implicitly
+    file.set(tasks.war.get().archiveFile)
     reload = false
-    dependsOn("build-id", "build", "war")
 }
 tasks.war {
+    dependsOn("build-id")
     webInf {
         from("build.id")
     }

--- a/integration/settings.gradle.kts
+++ b/integration/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.namespace == "com.mkring.wildlydeplyplugin") {
-                useModule("com.mkring.wildlydeplyplugin:wildfly-deploy-gradle-plugin:0.2.10")
+                useModule("com.mkring.wildlydeplyplugin:wildfly-deploy-gradle-plugin:0.2.12")
             }
         }
     }

--- a/src/main/kotlin/com/mkring/wildlydeplyplugin/DeployWildflyPlugin.kt
+++ b/src/main/kotlin/com/mkring/wildlydeplyplugin/DeployWildflyPlugin.kt
@@ -56,7 +56,6 @@ open class DeployWildflyTask : DefaultTask() {
     init {
         group = "help"
         description = "Deploys files to a Wildfly und reloads it afterwards"
-        dependsOn("build")
         outputs.upToDateWhen { false }
     }
 

--- a/src/main/kotlin/com/mkring/wildlydeplyplugin/DeployWildflyPlugin.kt
+++ b/src/main/kotlin/com/mkring/wildlydeplyplugin/DeployWildflyPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
@@ -26,9 +27,10 @@ open class DeployWildflyTask : DefaultTask() {
     var domainServerGroup: String = ""
 
     @Input
-    var deploymentName: String? = null
+    val deploymentName: Property<String> = project.objects.property(String::class.java)
+
     @Input
-    var runtimeName: String? = null
+    val runtimeName: Property<String> = project.objects.property(String::class.java)
 
     @Input
     var host: String = "localhost"
@@ -91,8 +93,8 @@ open class DeployWildflyTask : DefaultTask() {
                 password,
                 reload,
                 force,
-                deploymentName,
-                runtimeName,
+                deploymentName.get(),
+                runtimeName.get(),
                 domainServerGroup,
                 awaitReload,
                 undeployBeforehand,

--- a/src/main/kotlin/com/mkring/wildlydeplyplugin/DeployWildflyPlugin.kt
+++ b/src/main/kotlin/com/mkring/wildlydeplyplugin/DeployWildflyPlugin.kt
@@ -3,7 +3,9 @@ package com.mkring.wildlydeplyplugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.LoggerFactory
 
@@ -17,8 +19,8 @@ open class DeployWildflyPlugin : Plugin<Project> {
 open class DeployWildflyTask : DefaultTask() {
     val log = LoggerFactory.getLogger(DeployWildflyTask::class.java)
 
-    @Input
-    var file: String? = null
+    @InputFile
+    val file: RegularFileProperty = project.objects.fileProperty()
 
     @Input
     var domainServerGroup: String = ""
@@ -61,7 +63,7 @@ open class DeployWildflyTask : DefaultTask() {
 
     @TaskAction
     fun deployWildfly() {
-        if (file == null || user == null || password == null) {
+        if (file.get().asFile.name.isEmpty() || user == null || password == null) {
             log.error("DeployWildflyTask: missing configuration")
             return
         }
@@ -79,10 +81,10 @@ open class DeployWildflyTask : DefaultTask() {
         if (awaitRestart && restart.not()) {
             log.warn("awaitRestart is pointless if no restart is set")
         }
-        log.info("deployWildfly: going to deploy $file to $host:$port")
+        log.info("deployWildfly: going to deploy ${file.get().asFile} to $host:$port")
         try {
             FileDeployer(
-                file,
+                file.get().asFile,
                 host,
                 port,
                 user,

--- a/src/main/kotlin/com/mkring/wildlydeplyplugin/ExecuteWildflyTask.kt
+++ b/src/main/kotlin/com/mkring/wildlydeplyplugin/ExecuteWildflyTask.kt
@@ -21,7 +21,6 @@ open class ExecuteWildflyTask : DefaultTask() {
     init {
         group = "help"
         description = "Executes cli commands on a Wildfly"
-        dependsOn("build")
         outputs.upToDateWhen { false }
     }
 

--- a/src/main/kotlin/com/mkring/wildlydeplyplugin/FileDeployer.kt
+++ b/src/main/kotlin/com/mkring/wildlydeplyplugin/FileDeployer.kt
@@ -14,7 +14,7 @@ import java.time.temporal.ChronoUnit
 private val log = LoggerFactory.getLogger(FileDeployer::class.java)
 
 class FileDeployer(
-    private val file: String?,
+    private val file: File,
     private val host: String,
     private val port: Int,
     private val user: String?,
@@ -82,7 +82,7 @@ class FileDeployer(
                 ""
             }
 
-            val deploymentExists = File(file).isFile
+            val deploymentExists = file.isFile
             log.debug("given $file existent: $deploymentExists")
             if (deploymentExists.not()) throw IllegalStateException("couldn't find given deployment")
 


### PR DESCRIPTION
It is better to let the user manage the dependencies, especially since different deployment tasks may depend on different build tasks.
This PR changes the `file` property to use `@InputFile` annotations to allow Gradle to discover the build steps automatically instead of always relying on the `build` task to produce the archive to deploy.
Additionally, in order to allow the names for the archive, runtime and deployment to be lazily resolved, the properties are changed from plain `String` into Gradle [`Property<String>`](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Property.html) and [`RegularFileProperty`](https://docs.gradle.org/current/javadoc/org/gradle/api/file/RegularFileProperty.html)

The lazy configuration allows us to avoid adding an `afterEvaluate` block in build.gradle to set the file name for a project I have at work where the file name is configured from a number of other properties, (git commit id, gradle.properties, and some other things).

See also: https://docs.gradle.org/current/userguide/lazy_configuration.html